### PR TITLE
シーンマネージャの基盤完成～

### DIFF
--- a/SceneManager.cpp
+++ b/SceneManager.cpp
@@ -1,0 +1,100 @@
+﻿#include "SceneManager.h"
+
+int		SceneManager::existChangeRequest;		// シーン変更の要求が存在するか
+int		SceneManager::isEndDraw;				// 描画処理が終了したかどうか
+Scenes	SceneManager::scene_current;			// 現在のシーン
+Scenes	SceneManager::scene_next;				// リクエストが来たら代入
+
+int*	SceneManager::title;
+int*	SceneManager::stageSelect;
+int*	SceneManager::game;
+
+void SceneManager::ChangeRequest(Scenes _nextScene)
+{
+	existChangeRequest = 1;
+	scene_next = _nextScene;
+}
+
+void SceneManager::Update()
+{
+	switch (scene_current)
+	{
+	case Title:
+		//if (title) title->Update();
+		break;
+	case StageSelect:
+		//if (stageSelect) stageSelect->Update();
+		break;
+	case Game:
+		//if (game) game->Update();
+		break;
+
+	default:
+		break;
+	}
+}
+
+void SceneManager::Draw()
+{
+	switch (scene_current)
+	{
+	case Title:
+		//if (title) title->Draw();
+		break;
+	case StageSelect:
+		//if (stageSelect) stageSelect->Draw();
+		break;
+	case Game:
+		//if (game) game->Draw();
+		break;
+
+	default:
+		break;
+	}
+}
+
+void SceneManager::ChangeScene()
+{
+	/// シーンチェンジ要求が存在する場合...
+	if (existChangeRequest)
+	{
+		/// 描画が終了しているなら...
+		if (isEndDraw)
+		{
+			// シーンチェンジの演出があれば記述
+			switch (scene_current)
+			{
+			case Title:
+				delete title;
+				title = nullptr;
+				break;
+			case StageSelect:
+				delete stageSelect;
+				stageSelect = nullptr;
+				break;
+			case Game:
+				delete game;
+				game = nullptr;
+				break;
+			default:
+				break;
+			}
+
+			// インスタンスの作成
+			switch (scene_next)
+			{
+			case Title:
+				//title = new Title();
+				break;
+			case StageSelect:
+				//stageSelect = new StageSelect();
+				break;
+			case Game:
+				//game = new Game();
+				break;
+			default:
+				break;
+			}
+		}
+	}
+}

--- a/SceneManager.h
+++ b/SceneManager.h
@@ -1,0 +1,40 @@
+﻿#pragma once
+
+enum Scenes
+{
+	Title,
+	StageSelect,
+	Game,
+	// リザルトはゲームシーンに組み込み
+	// 全ステージクリア後はタイトルへ
+};
+
+class SceneManager
+{
+private:
+	static	int		existChangeRequest;		// シーン変更の要求が存在するか
+	static	int		isEndDraw;				// 描画処理が終了したかどうか
+	static	Scenes	scene_current;			// 現在のシーン
+	static	Scenes	scene_next;				// リクエストが来たら代入
+
+	// TODO: 型を変更してください
+	static	int*	title;					// タイトルシーン
+	static	int*	stageSelect;			// ステージセレクトシーン
+	static	int*	game;					// ゲームシーン
+
+public:
+	/// <summary>
+	///	次のフレームからシーンを変更します。
+	/// シーンチェンジの演出がある場合、演出が終わり次第変更します。
+	/// </summary>
+	/// <param name="_nextScene">次のシーン</param>
+	void	ChangeRequest(Scenes _nextScene);
+
+	// 更新処理
+	void	Update();
+	// 描画処理
+	void	Draw();
+	// ゲームループの最後に配置してください。※シーンチェンジ要求はChangeRequest関数を使用して下さい。
+	void	ChangeScene();
+
+};

--- a/TD1_3.vcxproj
+++ b/TD1_3.vcxproj
@@ -132,6 +132,7 @@ xcopy C:\KamataEngine\DirectXGame\Resources "$(OutDirFullPath)NoviceResources" /
     <ClCompile Include="UI\Slider.cpp" />
     <ClCompile Include="UI\UI_ToolKit.cpp" />
     <ClCompile Include="Tutorial.cpp" />
+    <ClCompile Include="SceneManager.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="box.h" />
@@ -178,6 +179,7 @@ xcopy C:\KamataEngine\DirectXGame\Resources "$(OutDirFullPath)NoviceResources" /
     <ClInclude Include="UI\UI_ToolKit.h" />
     <ClInclude Include="UI\UI_ToolKit_Defines.h" />
     <ClInclude Include="Tutorial.h" />
+    <ClInclude Include="SceneManager.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">


### PR DESCRIPTION
# class SceneManager
## メンバ関数
### void Update関数
シーンの更新処理です。ゲームループに配置してください。
### void Draw関数
シーンの描画処理です。ゲームループに配置してください。
### void ChangeScene関数
ゲームループの一番最後（描画フェーズの終わり）に配置して下さい。
### void ChangeRequest関数
  - パラメータ：`Scene _nextScene`
	次シーンを指定します。直接変更するのではなく一度バッファに入り、描画が終わり次第シーンを変更します。
  - 注意点
	演出が実装されている場合、SceneManagerに直接記述してください。その場合、演出の任意のタイミングで変更します。